### PR TITLE
Add firmware compilation workflows and fix typo in keyboard-tag

### DIFF
--- a/.github/workflows/compile-firmware-on-pull-request.yaml
+++ b/.github/workflows/compile-firmware-on-pull-request.yaml
@@ -1,0 +1,49 @@
+name: On-Pull-Request Compile
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  list-keymaps:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.list-keymaps.outputs.matrix }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: List Keymaps
+        id: list-keymaps
+        run: |
+          python -c "import os,json; print('matrix='+json.dumps({'include': [{'keymap': d} for d in os.listdir('keymaps') if os.path.isdir(os.path.join('keymaps', d))]}))" >> $GITHUB_OUTPUT
+    permissions:
+      contents: read
+  compile-hmproto34s:
+    needs: list-keymaps
+    strategy:
+      matrix: ${{fromJson(needs.list-keymaps.outputs.matrix)}}
+    uses: ./.github/workflows/compile-firmware-workflow-call.yaml
+    with:
+      git-ref: ${{ github.ref }}
+      keymap: ${{ matrix.keymap }}
+      keyboard: hmproto34s
+      keyboard-tag: "main"
+    permissions:
+      contents: read
+  compile-hmproto34:
+    needs: list-keymaps
+    strategy:
+      matrix: ${{fromJson(needs.list-keymaps.outputs.matrix)}}
+    uses: ./.github/workflows/compile-firmware-workflow-call.yaml
+    with:
+      git-ref: ${{ github.ref }}
+      keymap: ${{ matrix.keymap }}
+      keyboard: hmproto34
+      keyboard-tag: "main"
+    permissions:
+      contents: read

--- a/.github/workflows/compile-firmware-on-push-main.yaml
+++ b/.github/workflows/compile-firmware-on-push-main.yaml
@@ -1,0 +1,50 @@
+name: On-Push-Main Compile
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  list-keymaps:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.list-keymaps.outputs.matrix }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: List Keymaps
+        id: list-keymaps
+        run: |
+          python -c "import os,json; print('matrix='+json.dumps({'include': [{'keymap': d} for d in os.listdir('keymaps') if os.path.isdir(os.path.join('keymaps', d))]}))" >> $GITHUB_OUTPUT
+    permissions:
+      contents: read
+  compile-hmproto34s:
+    needs: list-keymaps
+    strategy:
+      matrix: ${{fromJson(needs.list-keymaps.outputs.matrix)}}
+    uses: ./.github/workflows/compile-firmware-workflow-call.yaml
+    with:
+      git-ref: ${{ github.ref }}
+      keymap: ${{ matrix.keymap }}
+      keyboard: hmproto34s
+      keyboard-tag: "main"
+    permissions:
+      contents: read
+  compile-hmproto34:
+    needs: list-keymaps
+    strategy:
+      matrix: ${{fromJson(needs.list-keymaps.outputs.matrix)}}
+    uses: ./.github/workflows/compile-firmware-workflow-call.yaml
+    with:
+      git-ref: ${{ github.ref }}
+      keymap: ${{ matrix.keymap }}
+      keyboard: hmproto34
+      keyboard-tag: "main"
+    permissions:
+      contents: read

--- a/.github/workflows/compile-firmware-on-release.yaml
+++ b/.github/workflows/compile-firmware-on-release.yaml
@@ -1,0 +1,80 @@
+name: On Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  list-keymaps:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.list-keymaps.outputs.matrix }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: List Keymaps
+        id: list-keymaps
+        run: |
+          python -c "import os,json; print('matrix='+json.dumps({'include': [{'keymap': d} for d in os.listdir('keymaps') if os.path.isdir(os.path.join('keymaps', d))]}))" >> $GITHUB_OUTPUT
+    permissions:
+      contents: read
+  compile-hmproto34s:
+    needs: list-keymaps
+    strategy:
+      matrix: ${{fromJson(needs.list-keymaps.outputs.matrix)}}
+    uses: ./.github/workflows/compile-firmware-workflow-call.yaml
+    with:
+      git-ref: ${{ github.ref }}
+      keymap: ${{ matrix.keymap }}
+      keyboard: hmproto34s
+      keyboard-tag: "main"
+    permissions:
+      contents: read
+  compile-hmproto34:
+    needs: list-keymaps
+    strategy:
+      matrix: ${{fromJson(needs.list-keymaps.outputs.matrix)}}
+    uses: ./.github/workflows/compile-firmware-workflow-call.yaml
+    with:
+      git-ref: ${{ github.ref }}
+      keymap: ${{ matrix.keymap }}
+      keyboard: hmproto34
+      keyboard-tag: "main"
+    permissions:
+      contents: read
+  deploy-to-github:
+    needs: [compile-hmproto34s, compile-hmproto34]
+    if: github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download hmproto34s firmware artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: hmproto34s-hmasdevmap
+          path: ./hmproto34s/
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download hmproto34 firmware artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: hmproto34-hmasdevmap
+          path: ./hmproto34/
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload .hex to GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ./hmproto34s/*.hex
+            ./hmproto34/*.hex
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RELEASE_ID: ${{ github.event.release.id }}
+    permissions:
+      contents: write
+      packages: read

--- a/.github/workflows/compile-firmware-on-schedule.yaml
+++ b/.github/workflows/compile-firmware-on-schedule.yaml
@@ -1,0 +1,49 @@
+name: Scheduled Compile
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 6"
+
+jobs:
+  list-keymaps:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.list-keymaps.outputs.matrix }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: List Keymaps
+        id: list-keymaps
+        run: |
+          python -c "import os,json; print('matrix='+json.dumps({'include': [{'keymap': d} for d in os.listdir('keymaps') if os.path.isdir(os.path.join('keymaps', d))]}))" >> $GITHUB_OUTPUT
+    permissions:
+      contents: read
+  compile-hmproto34s:
+    needs: list-keymaps
+    strategy:
+      matrix: ${{fromJson(needs.list-keymaps.outputs.matrix)}}
+    uses: ./.github/workflows/compile-firmware-workflow-call.yaml
+    with:
+      git-ref: ${{ github.ref }}
+      keymap: ${{ matrix.keymap }}
+      keyboard: hmproto34s
+      keyboard-tag: "main"
+    permissions:
+      contents: read
+  compile-hmproto34:
+    needs: list-keymaps
+    strategy:
+      matrix: ${{fromJson(needs.list-keymaps.outputs.matrix)}}
+    uses: ./.github/workflows/compile-firmware-workflow-call.yaml
+    with:
+      git-ref: ${{ github.ref }}
+      keymap: ${{ matrix.keymap }}
+      keyboard: hmproto34
+      keyboard-tag: "main"
+    permissions:
+      contents: read

--- a/.github/workflows/compile-firmware-workflow-call.yaml
+++ b/.github/workflows/compile-firmware-workflow-call.yaml
@@ -40,7 +40,7 @@ on:
         type: string
         default: "hmproto34s"
         description: "Keyboard name. Default is hmproto34s."
-      keyborad-tag:
+      keyboard-tag:
         required: false
         type: string
         default: "main"
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: hmasdev/${{ inputs.keyboard }}
-          ref: ${{ inputs.keyborad-tag }}
+          ref: ${{ inputs.keyboard-tag }}
           path: ${{ inputs.keyboard }}_firmware
       - name: Setup this repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Introduce new workflows for compiling firmware on pull requests, pushes to main, and scheduled events. Correct a typo in the keyboard-tag input within the compile workflow.