### PR TITLE
Feature: update vscode shortcuts

### DIFF
--- a/keymaps/hmasdevmap/keymap.c
+++ b/keymaps/hmasdevmap/keymap.c
@@ -21,6 +21,7 @@ enum custom_keycodes {
     CKC_EXIT,
     CKC_FU,
     CKC_HA,
+    CKC_MAKE,
     CKC_NN,
     CKC_NU,
     CKC_NYU,
@@ -37,6 +38,7 @@ enum custom_keycodes {
     CKC_L_ARROW,
     CKC_R_ARROW,
     /* PYTHON */
+    CKC_UV_RUN,
     CKC_PYTHON,
     CKC_PYTHONM,
     CKC_PIP_INSTALL,
@@ -61,6 +63,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case CKC_EXIT: if (record->event.pressed) { SEND_STRING("exit"); } return false; break;
         case CKC_FU: if (record->event.pressed) { SEND_STRING("fu"); } return false; break;
         case CKC_HA: if (record->event.pressed) { SEND_STRING("ha"); } return false; break;
+        case CKC_MAKE: if (record->event.pressed) { SEND_STRING("make"); } return false; break;
         case CKC_NN: if (record->event.pressed) { SEND_STRING("nn"); } return false; break;
         case CKC_NU: if (record->event.pressed) { SEND_STRING("nu"); } return false; break;
         case CKC_NYU: if (record->event.pressed) { SEND_STRING("nyu"); } return false; break;
@@ -77,6 +80,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case CKC_L_ARROW: if (record->event.pressed) { SEND_STRING("<- "); } return false; break;
         case CKC_R_ARROW: if (record->event.pressed) { SEND_STRING("-> "); } return false; break;
         // PYTHON
+        case CKC_UV_RUN: if (record->event.pressed) { SEND_STRING("uv run "); } return false; break;
         case CKC_PYTHON: if (record->event.pressed) { SEND_STRING("python "); } return false; break;
         case CKC_PYTHONM: if (record->event.pressed) { SEND_STRING("python -m "); } return false; break;
         case CKC_PIP_INSTALL: if (record->event.pressed) { SEND_STRING("pip install "); } return false; break;
@@ -241,9 +245,9 @@ const uint16_t PROGMEM KC_TD_QUOTE_CKC_NN[] = {TD(TD_QUOTE), CKC_NN, COMBO_END};
 
 combo_t key_combos[] = {
     // python
-    COMBO(KC_F2_F3, CKC_PYTHON),
-    COMBO(KC_F2_F3_F4, CKC_PYTHONM),
-    COMBO(KC_F1_F2_F3, CKC_PYTEST),
+    COMBO(KC_F2_F3, CKC_UV_RUN),
+    COMBO(KC_F2_F3_F4, CKC_PYTHON),
+    COMBO(KC_F1_F2_F3, CKC_PYTHONM),
     COMBO(KC_F1_F2_F3_F4, CKC_PIP_INSTALL),
     COMBO(KC_F3_F4, CKC_PY_NOQA),
     COMBO(KC_F4_F5, CKC_PY_TYPE_IGNORE),
@@ -341,7 +345,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [KL_OPE] = LAYOUT(
         CKC_EXIT,            CKC_WA,              KC_MS_UP,            CKC_FU,              CKC_BE,              CKC_WO,              CKC_NU,              KC_UP,               CKC_RO,              LGUI_T(KC_LBRC),
         CKC_ZA,              KC_MS_LEFT,          KC_MS_DOWN,          KC_MS_RIGHT,         KC_BTN1,             KC_HOME,             KC_LEFT,             KC_DOWN,             KC_RIGHT,            KC_END,
-        LSFT_T(KC_APP),      KC_WH_U,             KC_WH_D,             KC_BTN3,             KC_BTN2,             TD(TD_BRACKET_L),    TD(TD_BRACKET_R),    TD(TD_QUOTE),        CKC_NN,              LCTL_T(KC_INT1),
+        LSFT_T(KC_APP),      KC_WH_U,             KC_WH_D,             KC_BTN3,             KC_BTN2,             TD(TD_BRACKET_L),    TD(TD_BRACKET_R),    TD(TD_QUOTE),        CKC_MAKE,            LCTL_T(KC_INT1),
         LT(KL_SYMNUM, KC_TAB),XXXXXXX,            XXXXXXX,             XXXXXXX,             _______,             LSFT_T(KC_ENT),      XXXXXXX,             XXXXXXX,             XXXXXXX,             LALT_T(KC_QUOT)
     ),
 


### PR DESCRIPTION
This pull request updates the custom keyboard firmware by adding new keycodes and combos for improved Python and VSCode workflows, and refines several key mappings for better usability. The main changes include new custom keycodes for frequently used commands, enhancements to combo keys for Python development, and updates to the keymap layout for more ergonomic shortcuts.

**New custom keycodes and functionality:**

* Added `CKC_MAKE` to send the string "make" and included it in the QWERTY and OPE layers for quick access. [[1]](diffhunk://#diff-f26a2b230e9c9e044746d621aec9f5ffbbbdbcec7d69b39497756e0f42a6dfa7R24) [[2]](diffhunk://#diff-f26a2b230e9c9e044746d621aec9f5ffbbbdbcec7d69b39497756e0f42a6dfa7R66) [[3]](diffhunk://#diff-f26a2b230e9c9e044746d621aec9f5ffbbbdbcec7d69b39497756e0f42a6dfa7L307-R356)
* Added `CKC_UV_RUN` to send "uv run" and updated Python-related combos to use it, replacing the previous mapping for `KC_F2_F3`. [[1]](diffhunk://#diff-f26a2b230e9c9e044746d621aec9f5ffbbbdbcec7d69b39497756e0f42a6dfa7R41) [[2]](diffhunk://#diff-f26a2b230e9c9e044746d621aec9f5ffbbbdbcec7d69b39497756e0f42a6dfa7R83) [[3]](diffhunk://#diff-f26a2b230e9c9e044746d621aec9f5ffbbbdbcec7d69b39497756e0f42a6dfa7L207-R250)
* Introduced VSCode-related keycodes: `CKC_CTL_K_SFT_ENT` (for pin/unpin editor) and `CKC_CTL_K_CTL_ALT_S` (for Git: Stage Selected Ranges), with corresponding logic to send multi-modifier key sequences. These are also mapped in the FUN layer for easy access. [[1]](diffhunk://#diff-f26a2b230e9c9e044746d621aec9f5ffbbbdbcec7d69b39497756e0f42a6dfa7R52-R54) [[2]](diffhunk://#diff-f26a2b230e9c9e044746d621aec9f5ffbbbdbcec7d69b39497756e0f42a6dfa7R94-R127) [[3]](diffhunk://#diff-f26a2b230e9c9e044746d621aec9f5ffbbbdbcec7d69b39497756e0f42a6dfa7L307-R356)

**Combo and keymap improvements:**

* Updated combos for Python commands and changed some key combos for more intuitive access (e.g., `KC_HOME_LEFT` now triggers `CKC_NN` instead of `CKC_WO`). [[1]](diffhunk://#diff-f26a2b230e9c9e044746d621aec9f5ffbbbdbcec7d69b39497756e0f42a6dfa7L207-R250) [[2]](diffhunk://#diff-f26a2b230e9c9e044746d621aec9f5ffbbbdbcec7d69b39497756e0f42a6dfa7L229-R270)
* Changed the `KC_QW` combo to use `LGUI_T(KC_ESC)` instead of `KC_ESC`, providing a GUI-modified escape key.
* Refined the QWERTY and FUN layers: replaced some modifier-tap keys, adjusted function key mappings, and integrated the new custom keycodes for better workflow support. [[1]](diffhunk://#diff-f26a2b230e9c9e044746d621aec9f5ffbbbdbcec7d69b39497756e0f42a6dfa7L289-R332) [[2]](diffhunk://#diff-f26a2b230e9c9e044746d621aec9f5ffbbbdbcec7d69b39497756e0f42a6dfa7L307-R356)