### PR TITLE
fix: update keycodes for QW and QWDF combos to use LCTL_T instead of …

### DIFF
--- a/keymaps/hmasdevmap/keymap.c
+++ b/keymaps/hmasdevmap/keymap.c
@@ -217,7 +217,7 @@ const uint16_t PROGMEM KC_SPACE_M[] = {LT(KL_FUN, KC_SPACE), KC_M, COMBO_END};
 
 const uint16_t PROGMEM KC_XC[] = {KC_X, KC_C, COMBO_END};
 const uint16_t PROGMEM KC_ZX[] = {KC_Z, KC_X, COMBO_END};
-const uint16_t PROGMEM KC_QW[] = {LGUI_T(KC_Q), KC_W, COMBO_END};
+const uint16_t PROGMEM KC_QW[] = {LCTL_T(KC_Q), KC_W, COMBO_END};
 const uint16_t PROGMEM KC_ENT_L_BRACKET[] = {LSFT_T(KC_ENT), TD(TD_BRACKET_L), COMBO_END};
 const uint16_t PROGMEM KC_ENT_R_BRACKET[] = {LSFT_T(KC_ENT), TD(TD_BRACKET_R), COMBO_END};
 
@@ -227,8 +227,8 @@ const uint16_t PROGMEM KC_GRV_SPACE[] = {LALT_T(KC_GRV), LT(KL_FUN, KC_SPACE), C
 const uint16_t PROGMEM KC_ENT_KC_0[] = {KC_ENT, KC_0, COMBO_END};
 const uint16_t PROGMEM KC_ENT_KC_1[] = {KC_ENT, KC_1, COMBO_END};
 
-const uint16_t PROGMEM KC_QWER[] = {LGUI_T(KC_Q), KC_W, KC_E, KC_R, COMBO_END};
-const uint16_t PROGMEM KC_QWDF[] = {LGUI_T(KC_Q), KC_W, KC_D, KC_F, COMBO_END};
+const uint16_t PROGMEM KC_QWER[] = {LCTL_T(KC_Q), KC_W, KC_E, KC_R, COMBO_END};
+const uint16_t PROGMEM KC_QWDF[] = {LCTL_T(KC_Q), KC_W, KC_D, KC_F, COMBO_END};
 
 const uint16_t PROGMEM KC_F2_F3[] = {KC_F2, KC_F3, COMBO_END};
 const uint16_t PROGMEM KC_F1_F2_F3[] = {KC_F1, KC_F2, KC_F3, COMBO_END};


### PR DESCRIPTION
This pull request updates several combo key definitions in the `keymaps/hmasdevmap/keymap.c` file to use the Control modifier (`LCTL_T`) for the `KC_Q` key instead of the GUI modifier (`LGUI_T`). This change affects combos involving the `KC_Q` key, ensuring consistent modifier behavior.

Modifier changes for combo keys:

* Changed the modifier for `KC_Q` from GUI (`LGUI_T`) to Control (`LCTL_T`) in the `KC_QW` combo definition.
* Updated the modifier for `KC_Q` from GUI to Control in the `KC_QWER` and `KC_QWDF` combo definitions.…LGUI_T